### PR TITLE
handle N targets

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,23 @@ import (
 	"github.com/asaskevich/govalidator"
 )
 
+func validateUrl(u string) (*url.URL, error) {
+	// Verify the target is HTTP or HTTPS.
+	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+		return nil, fmt.Errorf("%s: must be an http(s) URL.\n", u)
+	}
+	// Validate the URL.
+	if !govalidator.IsURL(u) {
+		return nil, fmt.Errorf("%s: must be a valid URL.\n", u)
+	}
+	// Parse the target as a URL.
+	ua, err := url.Parse(u)
+	if err != nil {
+		panic(err)
+	}
+	return ua, nil
+}
+
 func main() {
 	if len(os.Args) < 3 {
 		fmt.Fprintln(os.Stderr, "USAGE: multireq [listen-addr] [target]...")
@@ -25,22 +42,10 @@ func main() {
 
 	failed := false
 	for i, v := range targets {
-		// Verify the target is HTTP or HTTPS.
-		if !strings.HasPrefix(v, "http://") && !strings.HasPrefix(v, "https://") {
-			fmt.Fprintf(os.Stderr, "%s: must be an http(s) URL.\n", v)
-			failed = true
-			continue
-		}
-		// Validate the URL.
-		if !govalidator.IsURL(v) {
-			fmt.Fprintf(os.Stderr, "%s: must be a valid URL.\n", v)
-			failed = true
-			continue
-		}
-		// Parse the target as a URL.
-		ua, err := url.Parse(v)
+		ua, err := validateUrl(v)
 		if err != nil {
-			panic(err)
+			fmt.Println(err.Error())
+			failed = true
 			continue
 		}
 		urls[i] = ua

--- a/main.go
+++ b/main.go
@@ -145,6 +145,11 @@ func main() {
 				}
 				log.Printf("io.Copy %d bytes written", written)
 				break
+			} else {
+				// Handle failure.
+				w.WriteHeader(500)
+				w.(http.Flusher).Flush()
+				break
 			}
 		}
 	})


### PR DESCRIPTION
In addition to handling N targets, I also made a few other changes while digging around:
- More standard/unixy USAGE format string
- Writes all usage & general errors to stderr rather than stdout
- URL validation (`url.Parse()` doesn't do validation)
- More comments throughout
- Returns `504 Gateway Timeout` when all targets fail (rather than `404 Not
  Found`)

Handling N targets ended up being a significant refactor, so it was difficult to separate that change from the above bullet pointed items. I can try and pull them all apart into separate commits, but they're all small things and shouldn't be too hard to examine inline.
