### PR TITLE
Treat 404 as a valid response.

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 			200: true,
 			304: true,
 			302: true,
+			404: true,
 		}
 
 		r.RequestURI = ""


### PR DESCRIPTION
Without this, there is a case on the public IPFS gateway where a user
requests, say, `ipfs.io/ipfs/Qmfoobar/hello`. Let's say `Qmfoobar` does
indeed exist (on v04x) but has no link named `hello`. It will return a 404
in this case. However, the v03x node will continue to search for it, hanging
indefinitely.
